### PR TITLE
fix publish to enter java folder before executing deploy

### DIFF
--- a/.github/workflows/pr_open.yml
+++ b/.github/workflows/pr_open.yml
@@ -31,9 +31,7 @@ jobs:
 
       - name: Update Maven Version
         run: |
-          cd api
-          ls -la
-          cd java
+          cd api/java
           echo "Current Version: $(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)"
           mvn build-helper:parse-version versions:set -DnewVersion=\${parsedVersion.majorVersion}.\${parsedVersion.minorVersion}.\${parsedVersion.nextIncrementalVersion} versions:commit
           echo "New Version: $(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)"

--- a/.github/workflows/publish_maven_package.yml
+++ b/.github/workflows/publish_maven_package.yml
@@ -17,6 +17,8 @@ jobs:
           distribution: 'corretto'
 
       - name: Publish package
-        run: mvn --batch-mode deploy
+        run: |
+          cd java
+          mvn --batch-mode deploy
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>org.simpledao</groupId>
     <artifactId>simpledao</artifactId>
-    <version>2.9.3</version>
+    <version>2.9.4</version>
     <name>SimpleDAO</name>
 
     <distributionManagement>


### PR DESCRIPTION
Added a fix for publish pipeline.  Previous version wasn't entering java sub folder before executing mvn deploy